### PR TITLE
Output and Formatting Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ While concuss is designed to be used as a command line tool, you can also includ
 require 'concuss'
 
 concuss = Concuss.new(url: 'http://localhost:4567', file: 'header_file.txt', header_set: :standard, test_string: "OOGABOOGA")
-concuss.attack!
+report = concuss.attack!
 ```
 
-This will spit out the results, which isn't super useful if you need to post process them... I'll work on that though.
+From there, you'll get a `Concuss::Report` object that contains the raw data as well as filters for `hits`, `misses`, `headers`, and the `url` in the event you've done a bunch of these.
 
 ## Demo
 

--- a/bin/concuss
+++ b/bin/concuss
@@ -31,5 +31,9 @@ if ARGV[0].nil?
 end
 
 options[:url] = ARGV[0]
+options[:formatter] = Concuss::Formatters::Table
+options[:progress_type] = :dots
+
+puts "Scanning #{options[:url]}"
 
 Concuss.new(**options).attack!

--- a/lib/concuss.rb
+++ b/lib/concuss.rb
@@ -3,25 +3,32 @@
 class Concuss
   class Error < StandardError; end
 
-  attr_reader :url, :file, :header_set, :headers, :test_string, :user_agent
+  attr_reader :url, :file, :header_set, :headers, :test_string, :user_agent, :formatter, :progress_type
 
-  def initialize(url:, file: nil, header_set: :all, test_string: nil, user_agent: nil)
+  def initialize(url:, file: nil, header_set: :all, test_string: nil, user_agent: nil, formatter: nil, progress_type: nil)
     @url = url
     @file = file
     @header_set = file.nil? ? header_set : :file
     @test_string = test_string
     @user_agent = user_agent
+    @formatter = formatter
+    @progress_type = progress_type
 
     @headers = Concuss::Headers.new(header_set: @header_set, file: @file).group
   end
 
   def attack!
-    runner = Concuss::Runner.new(headers: headers, url: url, test_string: test_string, user_agent: user_agent)
+    runner = Concuss::Runner.new(headers: headers, url: url, test_string: test_string, user_agent: user_agent, progress_type: progress_type)
+    results = runner.run
 
-    runner.run
+    formatter.new(results).print if formatter
+
+    return results
   end
 end
 
 require_relative "concuss/version"
+require_relative "concuss/report"
 require_relative "concuss/headers"
 require_relative "concuss/runner"
+require_relative "concuss/formatters"

--- a/lib/concuss/formatters.rb
+++ b/lib/concuss/formatters.rb
@@ -1,0 +1,6 @@
+class Concuss
+  module Formatters
+  end
+end
+
+require_relative 'formatters/table'

--- a/lib/concuss/formatters/table.rb
+++ b/lib/concuss/formatters/table.rb
@@ -1,0 +1,31 @@
+class Concuss::Formatters::Table
+
+  HEADINGS = ['HEADER', 'RESPONSE_CODE', 'HIT/MISS'].freeze
+
+  def initialize(report)
+    @report = report
+  end
+
+  def print
+    header_max_length = @report.headers.map(&:length).max
+    response_code_length = HEADINGS[1].length
+    hit_header_length = HEADINGS[2].length
+
+    header_format = "%-#{header_max_length}s | %-#{response_code_length}s | %-0s\n"
+    separator = '-' * (header_max_length + response_code_length + hit_header_length + 6)
+
+    puts header_format % HEADINGS
+    puts separator
+    print_data(@report.hits, header_format)
+    print_data(@report.misses, header_format)
+  end
+
+  private
+
+  def print_data(data, header_format)
+    data.sort.each do |header, values|
+      puts header_format % [header, values[:response_code], values[:hit] ? 'HIT' : 'MISS']
+    end
+  end
+end
+

--- a/lib/concuss/report.rb
+++ b/lib/concuss/report.rb
@@ -1,0 +1,20 @@
+class Concuss::Report
+  attr_reader :data, :url
+
+  def initialize(data:, url:)
+    @url = url
+    @data = data
+  end
+
+  def hits
+    data.select { |_, value| value[:hit] }
+  end
+
+  def misses
+    data.reject { |_, value| value[:hit] }
+  end
+
+  def headers
+    data.keys
+  end
+end

--- a/lib/concuss/runner.rb
+++ b/lib/concuss/runner.rb
@@ -3,18 +3,20 @@ require 'net/http'
 
 class Concuss::Runner
   DEFAULT_USER_AGENT = "Concuss/#{Concuss::VERSION}"
-  
-  attr_reader :headers, :url, :test_string, :user_agent
 
-  def initialize(headers:, url:, test_string: nil, user_agent: nil)
+  attr_reader :headers, :url, :test_string, :user_agent, :progress_type
+
+  def initialize(headers:, url:, test_string: nil, user_agent: nil, progress_type: nil)
     @headers = headers
     @url = url
     @test_string = test_string || SecureRandom.hex(25)
     @user_agent = user_agent || DEFAULT_USER_AGENT
+    @progress_type = progress_type
   end
 
   def run
     uri = URI(@url)
+    report_data = { }
 
     @headers.each do |header|
       response = Net::HTTP.get_response(uri,
@@ -24,14 +26,20 @@ class Concuss::Runner
         }
       )
 
-      if response.code == "200" && response.body.include?(@test_string)
-        result = "HIT"
-      else
-        result = "MISS"
-      end
+      hit = response.code == "200" && response.body.include?(@test_string)
+      report_data[header] = { response_code: response.code, hit: hit }
 
-      puts "#{header} - #{response.code} - #{result}"
+      case progress_type
+      when :full
+        puts "#{header} - #{response.code} - #{hit ? "HIT" : "MISS"}"
+      when :dots
+        print "."
+      end
     end
+
+    puts "" if progress_type == :dots
+
+    return Concuss::Report.new(data: report_data, url: @url)
   end
 end
 

--- a/spec/concuss/formatters/table_spec.rb
+++ b/spec/concuss/formatters/table_spec.rb
@@ -1,0 +1,29 @@
+require 'rspec'
+
+RSpec.describe Concuss::Formatters::Table do
+  let(:data) do
+    {
+      'X-CSRF-TOKEN' => { response_code: '200', hit: true },
+      'X-Requested-With' => { response_code: '404', hit: false },
+      'X-Forwarded-Proto' => { response_code: '500', hit: true }
+    }
+  end
+
+  let(:report) { Concuss::Report.new(data: data, url: "http://example.com") }
+  subject { described_class.new(report) }
+
+  describe '#print' do
+    it 'outputs the data in a table format' do
+      expected_output = <<-TABLE
+HEADER            | RESPONSE_CODE | HIT/MISS
+--------------------------------------------
+X-CSRF-TOKEN      | 200           | HIT
+X-Forwarded-Proto | 500           | HIT
+X-Requested-With  | 404           | MISS
+TABLE
+
+      expect { subject.print }.to output(expected_output).to_stdout
+    end
+  end
+end
+

--- a/spec/concuss/report_spec.rb
+++ b/spec/concuss/report_spec.rb
@@ -1,0 +1,37 @@
+require 'rspec'
+
+RSpec.describe Concuss::Report do
+  let(:data) do
+    {
+      'header_1' => { response_code: '200', hit: true },
+      'header_2' => { response_code: '404', hit: false },
+      'header_3' => { response_code: '500', hit: true }
+    }
+  end
+
+  subject { described_class.new(data: data, url: "http://example.com") }
+
+  describe '#hits' do
+    it 'returns the header/value pairs where hit is true' do
+      expect(subject.hits).to eq({
+        'header_1' => { response_code: '200', hit: true },
+        'header_3' => { response_code: '500', hit: true }
+      })
+    end
+  end
+
+  describe '#misses' do
+    it 'returns the header/value pairs where hit is false' do
+      expect(subject.misses).to eq({
+        'header_2' => { response_code: '404', hit: false }
+      })
+    end
+  end
+
+  describe '#headers' do
+    it 'returns the headers' do
+      expect(subject.headers).to eq(['header_1', 'header_2', 'header_3'])
+    end
+  end
+end
+

--- a/spec/concuss_spec.rb
+++ b/spec/concuss_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Concuss do
         url: 'https://example.com',
         file: file_path,
         test_string: 'example',
-        user_agent: user_agent
+        user_agent: user_agent,
+        progress_type: :dots,
+        formatter: Concuss::Formatters::Table
       )
 
       expect(concuss.url).to eq('https://example.com')
@@ -30,6 +32,8 @@ RSpec.describe Concuss do
       expect(concuss.test_string).to eq('example')
       expect(concuss.headers).to eq(fake_headers)
       expect(concuss.user_agent).to eq(user_agent)
+      expect(concuss.progress_type).to eq(:dots)
+      expect(concuss.formatter).to eq(Concuss::Formatters::Table)
     end
 
     it 'sets a default header_set if none are passed in' do
@@ -52,7 +56,8 @@ RSpec.describe Concuss do
         url: 'https://example.com',
         user_agent: user_agent,
         headers: Concuss::Headers.new(header_set: :all).group,
-        test_string: nil
+        test_string: nil,
+        progress_type: nil
       ).and_return(runner)
       concuss.attack!
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,13 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  def capture_stdout(&blk)
+    old = $stdout
+    $stdout = fake = StringIO.new
+    blk.call
+    fake.string
+  ensure
+    $stdout = old
+  end
 end


### PR DESCRIPTION
A number of changes to better support running in another application

* Added support for CLI formatters. Right now there's just a table formatter.
* Print out some dots when doing the scan so you can see progress. Will bring back a verbose mode later.
* Stop polluting stdout by default.
* Concuss::Report object that has the results of a scan for a URL.
