### PR TITLE
Make Dependabot ignore vuln_app and only do security releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        versions: ["*"]
+        update-types: ["all"]
+        directory: "/vuln_app"
+    allow:
+      - dependency-type: "direct"
+        update-types: ["security"]
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file. The changes modify the Dependabot configuration to ignore all updates except for direct security updates. 

The most important change is the addition of the `ignore` and `allow` directives. The `ignore` directive is configured to ignore all updates for all versions of all dependencies in the `/vuln_app` directory, while the `allow` directive is configured to allow only direct security updates. The `versioning-strategy` has also been set to `increase-if-necessary`.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L1-R15): Added `ignore` and `allow` directives to the Dependabot configuration. The `ignore` directive is configured to ignore all updates for all versions of all dependencies in the `/vuln_app` directory. The `allow` directive is configured to allow only direct security updates. Also, the `versioning-strategy` has been set to `increase-if-necessary`.