### PR TITLE
Add semver-major to the ignored version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
     versioning-strategy: increase-if-necessary
     reviewers:
       - "PatrickTulskie"


### PR DESCRIPTION
This pull request includes a small but significant change to the `.github/dependabot.yml` file. The change modifies the ignored update types for version updates to include major version updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R9): Changed the `update-types` configuration to include `version-update:semver-major` alongside minor and patch updates.